### PR TITLE
Test

### DIFF
--- a/harper-core/src/linting/its_contraction.rs
+++ b/harper-core/src/linting/its_contraction.rs
@@ -1,15 +1,17 @@
 use harper_brill::UPOS;
 
+use crate::TokenStringExt;
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::ExprExt;
 use crate::expr::SequenceExpr;
 use crate::patterns::NominalPhrase;
 use crate::patterns::Pattern;
 use crate::patterns::UPOSSet;
 use crate::patterns::WordSet;
 use crate::{
-    Token,
-    linting::{ExprLinter, Lint, LintKind, Suggestion},
+    Document, Token,
+    linting::{Lint, LintKind, Linter, Suggestion},
 };
 
 pub struct ItsContraction {
@@ -38,16 +40,35 @@ impl Default for ItsContraction {
     }
 }
 
-impl ExprLinter for ItsContraction {
-    fn expr(&self) -> &dyn Expr {
-        self.expr.as_ref()
+impl Linter for ItsContraction {
+    fn lint(&mut self, document: &Document) -> Vec<Lint> {
+        let mut lints = Vec::new();
+        let source = document.get_source();
+
+        for chunk in document.iter_chunks() {
+            lints.extend(
+                self.expr
+                    .iter_matches(chunk, source)
+                    .filter_map(|match_span| {
+                        self.match_to_lint(&chunk[match_span.start..], source)
+                    }),
+            );
+        }
+
+        lints
     }
 
+    fn description(&self) -> &str {
+        "Detects the possessive `its` before `had`, `been`, or `got` and offers `it's` or `it has`."
+    }
+}
+
+impl ItsContraction {
     fn match_to_lint(&self, toks: &[Token], source: &[char]) -> Option<Lint> {
         let offender = toks.first()?;
         let offender_chars = offender.span.get_content(source);
 
-        if !toks.get(2)?.kind.is_upos(UPOS::AUX)
+        if toks.get(2)?.kind.is_upos(UPOS::VERB)
             && NominalPhrase.matches(&toks[2..], source).is_some()
         {
             return None;
@@ -64,10 +85,6 @@ impl ExprLinter for ItsContraction {
                 .to_owned(),
             priority: 54,
         })
-    }
-
-    fn description(&self) -> &str {
-        "Detects the possessive `its` before `had`, `been`, or `got` and offers `it's` or `it has`."
     }
 }
 
@@ -136,6 +153,33 @@ mod tests {
             "Its a nice day.",
             ItsContraction::default(),
             "It's a nice day.",
+        );
+    }
+
+    #[test]
+    fn ignore_nominal_progressive() {
+        assert_lint_count(
+            "The class preserves its existing properties.",
+            ItsContraction::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn ignore_nominal_perfect() {
+        assert_lint_count(
+            "The robot followed its predetermined route.",
+            ItsContraction::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn ignore_nominal_long() {
+        assert_lint_count(
+            "I think of its exploding marvelous spectacular output.",
+            ItsContraction::default(),
+            0,
         );
     }
 }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -398,7 +398,7 @@ impl LintGroup {
         insert_struct_rule!(HopHope, true);
         insert_struct_rule!(HowTo, true);
         insert_pattern_rule!(HyphenateNumberDay, true);
-        insert_pattern_rule!(ItsContraction, true);
+        insert_struct_rule!(ItsContraction, true);
         insert_pattern_rule!(LeftRightHand, true);
         insert_pattern_rule!(LessWorse, true);
         insert_struct_rule!(LetsConfusion, true);

--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -13,14 +13,12 @@ impl Pattern for NominalPhrase {
             let tok = tokens.get(cursor)?;
 
             if tok.kind.is_adjective() || tok.kind.is_determiner() {
-                let next = tokens.get(cursor + 1)?;
-
-                if !next.kind.is_whitespace() {
-                    return None;
+                if let Some(next) = tokens.get(cursor + 1) {
+                    if next.kind.is_whitespace() {
+                        cursor += 2;
+                        continue;
+                    }
                 }
-
-                cursor += 2;
-                continue;
             }
 
             if tok.kind.is_nominal() {
@@ -111,5 +109,15 @@ mod tests {
             matches.to_strings(&doc),
             vec!["My favorite foods", "pizza", "sushi", "tacos", "burgers"]
         )
+    }
+
+    #[test]
+    fn simplest_way() {
+        let doc = Document::new_markdown_default_curated("a way");
+        assert!(
+            NominalPhrase
+                .matches(doc.get_tokens(), doc.get_source())
+                .is_some()
+        );
     }
 }

--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -12,7 +12,10 @@ impl Pattern for NominalPhrase {
         loop {
             let tok = tokens.get(cursor)?;
 
-            if tok.kind.is_adjective() || tok.kind.is_determiner() {
+            if tok.kind.is_adjective()
+                || tok.kind.is_determiner()
+                || tok.kind.is_verb_progressive_form()
+            {
                 if let Some(next) = tokens.get(cursor + 1) {
                     if next.kind.is_whitespace() {
                         cursor += 2;
@@ -114,6 +117,26 @@ mod tests {
     #[test]
     fn simplest_way() {
         let doc = Document::new_markdown_default_curated("a way");
+        assert!(
+            NominalPhrase
+                .matches(doc.get_tokens(), doc.get_source())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn progressive_way() {
+        let doc = Document::new_markdown_default_curated("a winning way");
+        assert!(
+            NominalPhrase
+                .matches(doc.get_tokens(), doc.get_source())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn perfect_way() {
+        let doc = Document::new_markdown_default_curated("a failed way");
         assert!(
             NominalPhrase
                 .matches(doc.get_tokens(), doc.get_source())

--- a/harper-core/tests/run_tests.rs
+++ b/harper-core/tests/run_tests.rs
@@ -85,7 +85,7 @@ create_test!(pr_452.md, 2, Dialect::American);
 create_test!(hex_basic_clean.md, 0, Dialect::American);
 create_test!(hex_basic_dirty.md, 1, Dialect::American);
 create_test!(misc_closed_compound_clean.md, 0, Dialect::American);
-create_test!(yogurt_british_clean.md, 1, Dialect::British);
+create_test!(yogurt_british_clean.md, 0, Dialect::British);
 
 // Make sure it doesn't panic
 create_test!(lukas_homework.md, 3, Dialect::American);

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -7549,16 +7549,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (54 priority)
-Message: |
-    5814 | green breast of the new world. Its vanished trees, the trees that had made way
-         |                                ^~~ Use `it's` (short for `it has` or `it is`) here, not the possessive `its`.
-Suggest:
-  - Replace with: “It's”
-  - Replace with: “It has”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     5814 | green breast of the new world. Its vanished trees, the trees that had made way


### PR DESCRIPTION
fix(core): support progressive/perfect forms after "its" + 1

# Issues 
<!-- Link any relevant GitHub issues here. -->
Fixes `#1463`.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
This PR fixes `harper-core` to support progressive/perfect forms after "its"; e.g., its existing properties, its vanished trees, etc. The bug was probably introduced with `f0bcaa0`.

Commit-by-commit explanation:
- 044941d: `NominalPhrase` is modified to support an input where the last word can be both adjective/determiner and also nominal(noun/pronoun); e.g., a way. 
  - Now that I think of it, this is not *technically required* for this PR, but I'm hoping it's good to have.
- ed4cbd9: `NominalPhrase` is again modified to support progressive/perfect forms; e.g., a winning way, a failed way. Since perfect forms are always adjectives, we have that for free. 
- 1ca65d3: Finally `ItsContraction` is modified to fix ignoring a nominal phrase after "its."
  - As a `ExprLinter`, sending `&toks[2..]` to `NominalPhrase.matches` isn't right since `toks` is always `["its", " ", VERB or AUX or DET]` thanks to `positive`. `ItsContraction` is now changed to `Linter` so that `toks` can contain more tokens; e.g., `["its", " ", "existing", " ", "properties", "."]`. 
  - The `NominalPhrase.matches` check is invoked only when the next word is a `VERB`, rather than `not AUX`. If not, "Its a nice day" passes the test since "a nice day" is a nominal phrase. Excluding `DET` out of the three makes sense in that any nominal phrase that start with a determiner can't be used after "its."

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/60a1f83d-eb8d-46c0-a787-fb5202da8e69" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Manually and with unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
